### PR TITLE
get_persistent_credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4  # Use the latest stable version (v4)
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/test.py
+++ b/test.py
@@ -1,21 +1,18 @@
 import ee
 import json
 import os
-import google.oauth2.credentials
 
 # Load credentials from the environment variable
 stored = json.loads(os.getenv("EARTHENGINE_TOKEN"))
-credentials = google.oauth2.credentials.Credentials(
-    None,
-    token_uri="https://oauth2.googleapis.com/token",
-    client_id=stored["client_id"],
-    client_secret=stored["client_secret"],
-    refresh_token=stored["refresh_token"],
-    quota_project_id=stored["project"],
-)
 
-# Initialize the Earth Engine API with the credentials
-ee.Initialize(credentials=credentials)
+# Write credentials to the appropriate Earth Engine credentials file
+credentials_file = os.path.expanduser("~/.config/earthengine/credentials")
+os.makedirs(os.path.dirname(credentials_file), exist_ok=True)  # Ensure the directory exists
+with open(credentials_file, 'w') as f:
+    json.dump(stored, f)
+
+# Initialize the Earth Engine API
+ee.Initialize()
 
 # Print a greeting message from the Earth Engine servers
 print(ee.String("Greetings from the Earth Engine servers!").getInfo())


### PR DESCRIPTION
Since i'm writing the credentials secret to ~/.config/earthengine/credentials, ishould not need to use google.oauth2.credentials.Credentials. Ican probably just use [ee.data.get_persistent_credentials()](https://github.com/google/earthengine-api/blob/b281501ad3b21a5f33848444e29b3aa21c8ec04c/python/ee/data.py#L244C5-L244C33) and pass that to ee.Initialize(credentials=credentials).