### PR TITLE
Create the configuration directly on the workflow rather than in the test.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install earthengine-api
 
+      - name: Configure Earth Engine token
+        env:
+          EARTHENGINE_TOKEN: ${{ secrets.EARTHENGINE_TOKEN }}
+        run: |
+          mkdir -p ~/.config/earthengine
+          echo "$EARTHENGINE_TOKEN" > ~/.config/earthengine/credentials
+
       - name: Run Earth Engine Script
         env:
           EARTHENGINE_TOKEN: ${{ secrets.EARTHENGINE_TOKEN }}

--- a/test.py
+++ b/test.py
@@ -1,15 +1,4 @@
 import ee
-import json
-import os
-
-# Load credentials from the environment variable
-stored = json.loads(os.getenv("EARTHENGINE_TOKEN"))
-
-# Write credentials to the appropriate Earth Engine credentials file
-credentials_file = os.path.expanduser("~/.config/earthengine/credentials")
-os.makedirs(os.path.dirname(credentials_file), exist_ok=True)  # Ensure the directory exists
-with open(credentials_file, 'w') as f:
-    json.dump(stored, f)
 
 # Initialize the Earth Engine API
 ee.Initialize()


### PR DESCRIPTION
Update the workflow file with `
      - name: Configure Earth Engine token
        env:
          EARTHENGINE_TOKEN: ${{ secrets.EARTHENGINE_TOKEN }}
        run: |
          mkdir -p ~/.config/earthengine
          echo "$EARTHENGINE_TOKEN" > ~/.config/earthengine/credentials`